### PR TITLE
Fix minor version check for PermGen

### DIFF
--- a/bin/jmeter.bat
+++ b/bin/jmeter.bat
@@ -82,7 +82,7 @@ set NEW=-XX:NewSize=128m -XX:MaxNewSize=128m
 set SURVIVOR=-XX:SurvivorRatio=8 -XX:TargetSurvivorRatio=50%
 set TENURING=-XX:MaxTenuringThreshold=2
 rem Java 8 remove Permanent generation, don't settings the PermSize
-if %current_minor% LEQ "8" (
+if %current_minor% LSS 8 (
     rem Increase MaxPermSize if you use a lot of Javascript in your Test Plan :
     set PERM=-XX:PermSize=64m -XX:MaxPermSize=128m
 )


### PR DESCRIPTION
The check for the PermGen to apply the flags for Java versions less than 8 was incorrect. The correct operator is LSS, not LEQ (which is Less Than or Equal to) and the value should not be quoted in this case.

As it was, the check would always fail, thus doing the right thing for Java 8 but 6 and 7 would have JMeter run without this flag set. I ran into this problem with a client's server. Normally we'd use a Linux box but we don't always get what we want in this life.
